### PR TITLE
Fix pandas indexing errors in rollup row detection

### DIFF
--- a/pdf_to_xls_vision.py
+++ b/pdf_to_xls_vision.py
@@ -465,18 +465,30 @@ def identify_rollup_rows(df):
     # Check if Row_Type column exists
     if 'Row_Type' in df.columns:
         for idx in df.index:
-            row_type = df.at[idx, 'Row_Type']
-            if pd.notna(row_type) and str(row_type).strip().upper() == 'ROLLUP':
-                rollup_rows.append(idx)
+            try:
+                row_type = df.loc[idx, 'Row_Type']
+                # Handle case where loc returns a Series
+                if isinstance(row_type, pd.Series):
+                    row_type = row_type.iloc[0] if len(row_type) > 0 else None
+                if pd.notna(row_type) and str(row_type).strip().upper() == 'ROLLUP':
+                    rollup_rows.append(idx)
+            except (KeyError, IndexError):
+                continue
     else:
         # Fallback: identify by naming patterns
         first_col = df.columns[0]
         for idx in df.index:
-            value = df.at[idx, first_col]
-            if pd.notna(value):
-                value_lower = str(value).lower().strip()
-                if any(indicator in value_lower for indicator in rollup_indicators):
-                    rollup_rows.append(idx)
+            try:
+                value = df.loc[idx, first_col]
+                # Handle case where loc returns a Series
+                if isinstance(value, pd.Series):
+                    value = value.iloc[0] if len(value) > 0 else None
+                if pd.notna(value):
+                    value_lower = str(value).lower().strip()
+                    if any(indicator in value_lower for indicator in rollup_indicators):
+                        rollup_rows.append(idx)
+            except (KeyError, IndexError):
+                continue
 
     return rollup_rows
 


### PR DESCRIPTION
## Summary
- Fixed pandas indexing errors in `identify_rollup_rows()` function that caused crashes when processing certain table structures
- Resolved two errors: "Invalid call for scalar access (getting)" and "The truth value of a Series is ambiguous"

## Changes
- Replaced `df.at[]` accessor with `df.loc[]` to handle duplicate indices properly
- Added `isinstance` checks to handle cases where `loc` returns a Series instead of a scalar
- Added try/except blocks to gracefully handle `KeyError` and `IndexError` exceptions
- Improved robustness when detecting rollup rows in both Row_Type column and naming pattern fallback

## Testing
Tested with TIVOLI-DC files:
- ✅ `Tivoli Place OM Final-compressed_1.pdf` - 17 sheets (was failing, now succeeds)
- ✅ `Tivoli Place Income-Expenses & General Ledger.pdf` - 4 sheets 
- ✅ `Tivoli Place - Rent Roll - 1.25.24.xlsx` - 2 sheets
- ✅ `Tivoli Place - Rent Roll 6.25.24.pdf` - 3 sheets (was failing, now succeeds)

All 4 PDFs now process successfully with rollup row detection working correctly.

## Related Issues
- Discovered while processing TIVOLI-DC files
- Also created Issue #13 for handling pages exceeding 5MB API limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)