### PR TITLE
Fix: Fallback to Vision API when pdfplumber finds no tables

### DIFF
--- a/pdf_to_xls/converter.py
+++ b/pdf_to_xls/converter.py
@@ -81,10 +81,14 @@ def convert_pdf_to_excel(
             print("  Text-based PDF, using direct extraction...")
             tables, quality_issues_detected = extract_tables_from_text_pdf(pdf_path)
 
-            # Auto-retry with Vision API if quality issues detected
-            if quality_issues_detected:
-                print("\n  ⚠️  Quality issues detected in text extraction!")
-                print("  🔄 Retrying with Vision API for better accuracy...\n")
+            # Auto-retry with Vision API if quality issues detected OR no tables found
+            if quality_issues_detected or not tables:
+                if quality_issues_detected:
+                    print("\n  ⚠️  Quality issues detected in text extraction!")
+                    print("  🔄 Retrying with Vision API for better accuracy...\n")
+                else:
+                    print("\n  ⚠️  No tables found with text extraction!")
+                    print("  🔄 Retrying with Vision API...\n")
 
                 # Get API configuration
                 if not api_key:


### PR DESCRIPTION
## Summary

Fixes a bug where the library would exit early and return None when pdfplumber finds no tables during text extraction, without attempting the Vision API fallback even when quality issues might exist.

**Changes:**
- Modified `pdf_to_xls/converter.py` to trigger Vision API fallback when either:
  - Quality issues are detected (existing behavior), OR
  - No tables are found by pdfplumber (new behavior)
- Added user-friendly messages to distinguish between quality issues and no tables found

**Impact:**
- Improves robustness for PDFs where pdfplumber fails to detect tables
- Ensures Vision API is used as a last resort before giving up
- Better user experience with clear messaging about why Vision API is being used

## Test plan

- [ ] Test with a PDF where pdfplumber finds no tables (should now fallback to Vision API)
- [ ] Test with a text-based PDF that has tables (should use fast text extraction)
- [ ] Test with image-based PDFs (should continue using Vision API as before)
- [ ] Test with `force_vision=True` flag (should continue working as before)
- [ ] Verify quality issue detection still triggers Vision API fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)